### PR TITLE
Use cross origin, pass linkId as a query string param

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,32 @@
+$(function(){
 
-function loadIt(){
-var linkID = $('#linkID').val();
-  if(linkID == 'undefined' || linkID == '' || linkID == null){
-    alert('Please enter the name of your hero')
-} else {
-    console.log(linkID);
-$.ajax({url:"https://gateway.marvel.com:443/v1/public/characters?orderBy=name&limit=10&apikey=bc8bc29e1ad131498d1f3edfd064b9a1" + linkID})
-  .done(function(stuff){
-  var holder = $('<div class="holders"></div>');
-  $.each(stuff.data.results,function(req, res) {
-    holder.append($('<img/>').attr('src',res.thumbnail.path + '/portrait_uncanny.' + res.thumbnail.extension));
-    holder.append('<br>' + 'Hero: ' + res.name);
-    holder.append('<br>' + 'Copies ' + res.comics.available);
-  $('.content').append(holder);
-  })
-$('.content').empty().append(holder);
-  })
-
-.fail(function(){
-alert('Retry that search silly human.')
-    })
+  function loadIt(){
+    var linkID = $('#linkID').val();
+    if(linkID == 'undefined' || linkID == '' || linkID == null){
+      alert('Please enter the name of your hero')
+    } else {
+      console.log(linkID);
+      $.ajax({
+        url: "http://gateway.marvel.com:80/v1/public/characters?name="+encodeURIComponent(linkID)+"&apikey=bc8bc29e1ad131498d1f3edfd064b9a1",
+        crossOrigin: true
+      })
+      .done(function(stuff){
+        console.log('got stuff', stuff);
+        var holder = $('<div class="holders"></div>');
+        $.each(stuff.data.results,function(req, res) {
+          holder.append($('<img/>').attr('src',res.thumbnail.path + '/portrait_uncanny.' + res.thumbnail.extension));
+          holder.append('<br>' + 'Hero: ' + res.name);
+          holder.append('<br>' + 'Copies ' + res.comics.available);
+          $('.content').append(holder);
+        })
+        $('.content').empty().append(holder);
+      })
+      .fail(function(){
+        alert('Retry that search silly human.')
+      })
     }
-}
-$('#send').on('click', loadIt);
+  }
+
+  $('#send').on('click', loadIt);
+  
+})


### PR DESCRIPTION
You were putting the linkid at the end of your URL. The problem is that you weren't formatting it like the api wants so it was getting added to the end of your api key instead of being used as the 'name' query string parameter. This meant that the api key was incorrect, thus throwing a 401 unauthorized.